### PR TITLE
Resolved race condition which could cause memory corruption and segmentation faults

### DIFF
--- a/tm_driver/src/tm_ros2_svr.cpp
+++ b/tm_driver/src/tm_ros2_svr.cpp
@@ -169,9 +169,11 @@ void TmSvrRos2::fake_publisher()
       // Publish feedback state
       pm.fbs_msg.header.stamp = node->rclcpp::Node::now();
       {
+        state.mtx_lock();//make sure to lock state before reading it
         pm.fbs_msg.joint_pos = state.joint_angle();
         pm.fbs_msg.joint_vel = state.joint_speed();
         pm.fbs_msg.joint_tor = state.joint_torque();
+        state.mtx_unlock();//unlock it when done
       }
       pm.fbs_pub->publish(pm.fbs_msg);
 


### PR DESCRIPTION
The function TmSrvRos2::publish_fbs() might read the robot state object at the same time as another thread is writing to it. The robot state object contains a lot of std::vector elements, which are not thread safe and can cause memory corruption if they are copied while another thread is modifying them. This memory corruption could in some cases trigger a segmentation fault.

Due to the random nature of race conditions, the nature of this bug is hard to verify with 100% certainty. However, before the change listed in this pull request, Valgrind reported several memory errors per hour (however, only a tiny fraction of the memory errors lead to segmentation faults, most weren't normally visible to the user). Now, with the patch of this pull request applied, it has been running for several hours with not a single memory being reported by Valgrind.

This patch thus seems to fix issue #3.